### PR TITLE
fix: don't use entrypoints in loader

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -9,7 +9,7 @@
     "jsxImportSource": "preact"
   },
   "imports": {
-    "@deno/loader": "jsr:@deno/loader@^0.2.1",
+    "@deno/loader": "jsr:@deno/loader@^0.3.0",
     "@std/expect": "jsr:@std/expect@^1.0.16",
     "@std/path": "jsr:@std/path@^1.1.1",
     "esbuild": "npm:esbuild@^0.25.5",
@@ -21,5 +21,6 @@
   },
   "publish": {
     "exclude": [".github/", "tests/"]
-  }
+  },
+  "exclude": ["./tests/fixtures/virtual.ts"]
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@deno/loader@~0.2.1": "0.2.1",
+    "jsr:@deno/loader@0.3": "0.3.0",
     "jsr:@marvinh-test/fresh-island@*": "0.0.1",
     "jsr:@std/assert@1": "1.0.13",
     "jsr:@std/assert@^1.0.13": "1.0.13",
@@ -18,8 +18,8 @@
     "npm:preact@^10.26.8": "10.26.8"
   },
   "jsr": {
-    "@deno/loader@0.2.1": {
-      "integrity": "c9fcc7309ce6a77306d37a7dc4b886e547aafc5204a4a28b0eafa523ffa5c9fc"
+    "@deno/loader@0.3.0": {
+      "integrity": "f6a293012922c3c560ae0fb24db2065566f8307f48fceac2d4ddfcce5fd3a9d7"
     },
     "@marvinh-test/fresh-island@0.0.1": {
       "integrity": "890f2595e60b1aaeaa8d73c6ad2c1247d4c5b895387df230f7f3b2a4da29b585",
@@ -245,7 +245,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@deno/loader@~0.2.1",
+      "jsr:@deno/loader@0.3",
       "jsr:@std/expect@^1.0.16",
       "jsr:@std/path@^1.1.1",
       "npm:esbuild@~0.25.5",

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -41,28 +41,7 @@ export function denoPlugin(options: DenoPluginOptions = {}): Plugin {
         preserveJsx: options.preserveJsx,
       });
 
-      // Normalize entrypoints for deno graph
-      const entrypoints: string[] = [];
-      const rawEntries = ctx.initialOptions.entryPoints;
-      if (rawEntries !== undefined) {
-        if (Array.isArray(rawEntries)) {
-          for (const entry of rawEntries) {
-            if (typeof entry === "string") {
-              entrypoints.push(entry);
-            } else {
-              entrypoints.push(entry.in);
-            }
-          }
-        } else {
-          for (const [_name, file] of Object.entries(rawEntries)) {
-            entrypoints.push(file);
-          }
-        }
-      }
-
-      const loader = await workspace.createLoader({
-        entrypoints,
-      });
+      const loader = await workspace.createLoader();
 
       ctx.onDispose(() => {
         loader[Symbol.dispose]?.();

--- a/tests/bundle.test.ts
+++ b/tests/bundle.test.ts
@@ -152,66 +152,6 @@ Deno.test({
 });
 
 Deno.test({
-  name: "entrypoint - jsr:",
-  fn: async () => {
-    await testEsbuild({
-      entryPoints: ["jsr:@marvinh-test/fresh-island"],
-    });
-  },
-  sanitizeResources: false,
-  sanitizeOps: false,
-});
-
-Deno.test({
-  name: "entrypoint - npm:",
-  fn: async () => {
-    await testEsbuild({
-      entryPoints: ["npm:preact"],
-    });
-  },
-  sanitizeResources: false,
-  sanitizeOps: false,
-});
-
-Deno.test({
-  name: "entrypoint - https:",
-  fn: async () => {
-    await testEsbuild({
-      entryPoints: ["https://esm.sh/preact"],
-    });
-  },
-  sanitizeResources: false,
-  sanitizeOps: false,
-});
-
-Deno.test({
-  name: "entrypoint - file:",
-  fn: async () => {
-    await testEsbuild({
-      entryPoints: [
-        path.toFileUrl(path.join(import.meta.dirname!, "fixtures", "simple.ts"))
-          .href,
-      ],
-    });
-  },
-  sanitizeResources: false,
-  sanitizeOps: false,
-});
-
-Deno.test({
-  name: "entrypoint - mapped:",
-  fn: async () => {
-    await testEsbuild({
-      entryPoints: [
-        "mapped",
-      ],
-    });
-  },
-  sanitizeResources: false,
-  sanitizeOps: false,
-});
-
-Deno.test({
   name: "plugins can participate in resolution",
   fn: async () => {
     const res = await testEsbuild({


### PR DESCRIPTION
Thanks to recent changes in `@deno/loader` we don't need to pass entrypoints anymore.

Fixes https://github.com/denoland/deno-esbuild-plugin/issues/5