### PR TITLE
feat: Add ability to split deno plugin into a resolver and loader plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,26 @@ await esbuild.build({
 });
 ```
 
+If you have another plugin that needs to be setup between Deno's resolver and
+loaer, you can split the plugin using denoPlugins instead of denoPlugin.
+
+```ts
+import * as esbuild from "esbuild";
+import { denoPlugins } from "@deno/esbuild-plugin";
+
+const [denoResolverPlugin, denoLoaderPlugin] = denoPlugins();
+await esbuild.build({
+  entryPoints: ["app.js"],
+  bundle: true,
+  outfile: "out.js",
+  plugins: [
+    denoResolverPlugin,
+    // other plugins
+    denoLoaderPlugin,
+  ],
+});
+```
+
 ## License
 
 MIT, see the [LICENSE file](./LICENSE).

--- a/deno.json
+++ b/deno.json
@@ -28,5 +28,5 @@
   "publish": {
     "exclude": [".github/", "tests/"]
   },
-  "exclude": ["./tests/fixtures/virtual.ts"]
+  "exclude": ["./tests/fixtures/virtual.ts", "./tests/fixtures/compiled.ts"]
 }

--- a/deno.json
+++ b/deno.json
@@ -28,5 +28,9 @@
   "publish": {
     "exclude": [".github/", "tests/"]
   },
-  "exclude": ["./tests/fixtures/virtual.ts", "./tests/fixtures/compiled.ts", "./tests/fixtures/mapped2.ts"]
+  "exclude": [
+    "./tests/fixtures/virtual.ts",
+    "./tests/fixtures/compiled.ts",
+    "./tests/fixtures/mapped2.ts"
+  ]
 }

--- a/deno.json
+++ b/deno.json
@@ -28,5 +28,5 @@
   "publish": {
     "exclude": [".github/", "tests/"]
   },
-  "exclude": ["./tests/fixtures/virtual.ts", "./tests/fixtures/compiled.ts"]
+  "exclude": ["./tests/fixtures/virtual.ts", "./tests/fixtures/compiled.ts", "./tests/fixtures/mapped2.ts"]
 }

--- a/deno.json
+++ b/deno.json
@@ -9,6 +9,7 @@
     "jsxImportSource": "preact"
   },
   "imports": {
+    "@fixtures/": "./tests/fixtures/",
     "@deno/loader": "jsr:@deno/loader@^0.3.10",
     "@std/expect": "jsr:@std/expect@^1.0.16",
     "@std/path": "jsr:@std/path@^1.1.1",

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,1 +1,1 @@
-export { denoPlugin, type DenoPluginOptions } from "./plugin.ts";
+export { denoPlugin, type DenoPluginOptions, denoPlugins } from "./plugin.ts";

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -51,12 +51,8 @@ async function setupPlugin(
 
   const loader = await workspace.createLoader();
 
-  let disposed = false;
   ctx.onDispose(() => {
-    if (!disposed) {
-      loader[Symbol.dispose]?.();
-      disposed = true;
-    }
+    loader[Symbol.dispose]?.();
   });
 
   return loader;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,5 @@
 import {
+  type Loader as WorkspaceLoader,
   MediaType,
   RequestedModuleType,
   ResolutionMode,
@@ -13,6 +14,7 @@ import type {
   OnResolveResult,
   Platform,
   Plugin,
+  PluginBuild,
 } from "esbuild";
 import * as path from "@std/path";
 import { isBuiltin } from "node:module";
@@ -34,6 +36,163 @@ export interface DenoPluginOptions {
   publicEnvVarPrefix?: string;
 }
 
+async function setupPlugin(
+  ctx: PluginBuild,
+  options: DenoPluginOptions,
+): Promise<WorkspaceLoader> {
+  const workspace = new Workspace({
+    debug: options.debug,
+    configPath: options.configPath,
+    nodeConditions: ctx.initialOptions.conditions,
+    noTranspile: options.noTranspile,
+    preserveJsx: options.preserveJsx,
+    platform: getPlatform(ctx.initialOptions.platform),
+  });
+
+  const loader = await workspace.createLoader();
+
+  let disposed = false;
+  ctx.onDispose(() => {
+    if (!disposed) {
+      loader[Symbol.dispose]?.();
+      disposed = true;
+    }
+  });
+
+  return loader;
+}
+
+function setupResolverPlugin(ctx: PluginBuild, loader: WorkspaceLoader): void {
+  const externals = (ctx.initialOptions.external ?? []).map((item) =>
+    externalToRegex(item)
+  );
+
+  const onResolve = async (
+    args: OnResolveArgs,
+  ): Promise<OnResolveResult | null> => {
+    if (
+      isBuiltin(args.path) || externals.some((reg) => reg.test(args.path))
+    ) {
+      return {
+        path: args.path,
+        external: true,
+      };
+    }
+    const kind = args.kind === "require-call" || args.kind === "require-resolve"
+      ? ResolutionMode.Require
+      : ResolutionMode.Import;
+
+    try {
+      const res = await loader.resolve(args.path, args.importer, kind);
+
+      let namespace: string | undefined;
+      if (res.startsWith("file:")) {
+        namespace = "file";
+      } else if (res.startsWith("http:")) {
+        namespace = "http";
+      } else if (res.startsWith("https:")) {
+        namespace = "https";
+      } else if (res.startsWith("npm:")) {
+        namespace = "npm";
+      } else if (res.startsWith("jsr:")) {
+        namespace = "jsr";
+      }
+
+      const resolved = res.startsWith("file:") ? path.fromFileUrl(res) : res;
+
+      return {
+        path: resolved,
+        namespace,
+      };
+    } catch (err) {
+      const couldNotResolveReg =
+        /not a dependency and not in import map|Relative import path ".*?" not prefixed with/;
+
+      if (err instanceof Error && couldNotResolveReg.test(err.message)) {
+        return null;
+      }
+
+      throw err;
+    }
+  };
+
+  // Esbuild doesn't detect namespaces in entrypoints. We need
+  // a catchall resolver for that.
+  ctx.onResolve({ filter: /.*/ }, onResolve);
+  ctx.onResolve({ filter: /.*/, namespace: "file" }, onResolve);
+  ctx.onResolve({ filter: /.*/, namespace: "http" }, onResolve);
+  ctx.onResolve({ filter: /.*/, namespace: "https" }, onResolve);
+  ctx.onResolve({ filter: /.*/, namespace: "data" }, onResolve);
+  ctx.onResolve({ filter: /.*/, namespace: "npm" }, onResolve);
+  ctx.onResolve({ filter: /.*/, namespace: "jsr" }, onResolve);
+}
+
+interface LoaderPluginOptions {
+  publicEnvVarPrefix?: string;
+}
+
+function setupLoaderPlugin(
+  ctx: PluginBuild,
+  loader: WorkspaceLoader,
+  options: LoaderPluginOptions,
+): void {
+  const onLoad = async (args: OnLoadArgs): Promise<OnLoadResult | null> => {
+    const url =
+      args.path.startsWith("http:") || args.path.startsWith("https:") ||
+        args.path.startsWith("npm:") || args.path.startsWith("jsr:")
+        ? args.path
+        : path.toFileUrl(args.path).toString();
+
+    const moduleType = getModuleType(args.path, args.with);
+    const res = await loader.load(url, moduleType);
+
+    if (res.kind === "external") {
+      return null;
+    }
+
+    const esbuildLoader = mediaToLoader(res.mediaType);
+
+    const envPrefix = options.publicEnvVarPrefix;
+    if (
+      envPrefix &&
+      moduleType === RequestedModuleType.Default
+    ) {
+      let code = new TextDecoder().decode(res.code);
+
+      code = code.replaceAll(
+        /Deno\.env\.get\(["']([^)]+)['"]\)|process\.env\.([\w_-]+)/g,
+        (m, name, processName) => {
+          if (name !== undefined && name.startsWith(envPrefix)) {
+            return JSON.stringify(Deno.env.get(name));
+          }
+          if (
+            processName !== undefined && processName.startsWith(envPrefix)
+          ) {
+            return JSON.stringify(Deno.env.get(processName));
+          }
+          return m;
+        },
+      );
+
+      return {
+        contents: code,
+        loader: esbuildLoader,
+      };
+    }
+
+    return {
+      contents: res.code,
+      loader: esbuildLoader,
+    };
+  };
+  ctx.onLoad({ filter: /.*/, namespace: "file" }, onLoad);
+  ctx.onLoad({ filter: /.*/, namespace: "jsr" }, onLoad);
+  ctx.onLoad({ filter: /.*/, namespace: "npm" }, onLoad);
+  ctx.onLoad({ filter: /.*/, namespace: "http" }, onLoad);
+  ctx.onLoad({ filter: /.*/, namespace: "https" }, onLoad);
+  ctx.onLoad({ filter: /.*/, namespace: "data" }, onLoad);
+}
+
 /**
  * Create an instance of the Deno plugin for esbuild
  */
@@ -41,146 +200,46 @@ export function denoPlugin(options: DenoPluginOptions = {}): Plugin {
   return {
     name: "deno",
     async setup(ctx) {
-      const workspace = new Workspace({
-        debug: options.debug,
-        configPath: options.configPath,
-        nodeConditions: ctx.initialOptions.conditions,
-        noTranspile: options.noTranspile,
-        preserveJsx: options.preserveJsx,
-        platform: getPlatform(ctx.initialOptions.platform),
-      });
+      const loader = await setupPlugin(ctx, options);
 
-      const loader = await workspace.createLoader();
+      setupResolverPlugin(ctx, loader);
 
-      ctx.onDispose(() => {
-        loader[Symbol.dispose]?.();
-      });
-
-      const externals = (ctx.initialOptions.external ?? []).map((item) =>
-        externalToRegex(item)
-      );
-
-      const onResolve = async (
-        args: OnResolveArgs,
-      ): Promise<OnResolveResult | null> => {
-        if (
-          isBuiltin(args.path) || externals.some((reg) => reg.test(args.path))
-        ) {
-          return {
-            path: args.path,
-            external: true,
-          };
-        }
-        const kind =
-          args.kind === "require-call" || args.kind === "require-resolve"
-            ? ResolutionMode.Require
-            : ResolutionMode.Import;
-
-        try {
-          const res = await loader.resolve(args.path, args.importer, kind);
-
-          let namespace: string | undefined;
-          if (res.startsWith("file:")) {
-            namespace = "file";
-          } else if (res.startsWith("http:")) {
-            namespace = "http";
-          } else if (res.startsWith("https:")) {
-            namespace = "https";
-          } else if (res.startsWith("npm:")) {
-            namespace = "npm";
-          } else if (res.startsWith("jsr:")) {
-            namespace = "jsr";
-          }
-
-          const resolved = res.startsWith("file:")
-            ? path.fromFileUrl(res)
-            : res;
-
-          return {
-            path: resolved,
-            namespace,
-          };
-        } catch (err) {
-          const couldNotResolveReg =
-            /not a dependency and not in import map|Relative import path ".*?" not prefixed with/;
-
-          if (err instanceof Error && couldNotResolveReg.test(err.message)) {
-            return null;
-          }
-
-          throw err;
-        }
-      };
-
-      // Esbuild doesn't detect namespaces in entrypoints. We need
-      // a catchall resolver for that.
-      ctx.onResolve({ filter: /.*/ }, onResolve);
-      ctx.onResolve({ filter: /.*/, namespace: "file" }, onResolve);
-      ctx.onResolve({ filter: /.*/, namespace: "http" }, onResolve);
-      ctx.onResolve({ filter: /.*/, namespace: "https" }, onResolve);
-      ctx.onResolve({ filter: /.*/, namespace: "data" }, onResolve);
-      ctx.onResolve({ filter: /.*/, namespace: "npm" }, onResolve);
-      ctx.onResolve({ filter: /.*/, namespace: "jsr" }, onResolve);
-
-      const onLoad = async (
-        args: OnLoadArgs,
-      ): Promise<OnLoadResult | null> => {
-        const url =
-          args.path.startsWith("http:") || args.path.startsWith("https:") ||
-            args.path.startsWith("npm:") || args.path.startsWith("jsr:")
-            ? args.path
-            : path.toFileUrl(args.path).toString();
-
-        const moduleType = getModuleType(args.path, args.with);
-        const res = await loader.load(url, moduleType);
-
-        if (res.kind === "external") {
-          return null;
-        }
-
-        const esbuildLoader = mediaToLoader(res.mediaType);
-
-        const envPrefix = options.publicEnvVarPrefix;
-        if (
-          envPrefix &&
-          moduleType === RequestedModuleType.Default
-        ) {
-          let code = new TextDecoder().decode(res.code);
-
-          code = code.replaceAll(
-            /Deno\.env\.get\(["']([^)]+)['"]\)|process\.env\.([\w_-]+)/g,
-            (m, name, processName) => {
-              if (name !== undefined && name.startsWith(envPrefix)) {
-                return JSON.stringify(Deno.env.get(name));
-              }
-              if (
-                processName !== undefined && processName.startsWith(envPrefix)
-              ) {
-                return JSON.stringify(Deno.env.get(processName));
-              }
-              return m;
-            },
-          );
-
-          return {
-            contents: code,
-            loader: esbuildLoader,
-          };
-        }
-
-        return {
-          contents: res.code,
-          loader: esbuildLoader,
-        };
-      };
-      ctx.onLoad({ filter: /.*/, namespace: "file" }, onLoad);
-      ctx.onLoad({ filter: /.*/, namespace: "jsr" }, onLoad);
-      ctx.onLoad({ filter: /.*/, namespace: "npm" }, onLoad);
-      ctx.onLoad({ filter: /.*/, namespace: "http" }, onLoad);
-      ctx.onLoad({ filter: /.*/, namespace: "https" }, onLoad);
-      ctx.onLoad({ filter: /.*/, namespace: "data" }, onLoad);
+      const { publicEnvVarPrefix } = options;
+      setupLoaderPlugin(ctx, loader, { publicEnvVarPrefix });
     },
   };
+}
+
+/**
+ * Create instances of the Deno resolver and loader plugins for esbuild
+ */
+export function denoPlugins(options: DenoPluginOptions = {}): Plugin[] {
+  let loaderPromise: Promise<WorkspaceLoader> | undefined;
+  async function setup(ctx: PluginBuild): Promise<WorkspaceLoader> {
+    if (!loaderPromise) {
+      loaderPromise = setupPlugin(ctx, options);
+    }
+    return await loaderPromise;
+  }
+
+  const resolverPlugin: Plugin = {
+    name: "deno",
+    async setup(ctx) {
+      const loader = await setup(ctx);
+
+      setupResolverPlugin(ctx, loader);
+    },
+  };
+  const loaderPlugin: Plugin = {
+    name: "deno",
+    async setup(ctx) {
+      const loader = await setup(ctx);
+
+      const { publicEnvVarPrefix } = options;
+      setupLoaderPlugin(ctx, loader, { publicEnvVarPrefix });
+    },
+  };
+  return [resolverPlugin, loaderPlugin];
 }
 
 function mediaToLoader(type: MediaType): Loader {

--- a/tests/bundle.test.ts
+++ b/tests/bundle.test.ts
@@ -1,7 +1,14 @@
 import { expect } from "@std/expect";
-import { build, type BuildOptions } from "esbuild";
+import {
+  build,
+  type BuildOptions,
+  type OnLoadArgs,
+  OnResolveArgs,
+  type Plugin,
+} from "esbuild";
 import { denoPlugin } from "@deno/esbuild-plugin";
 import * as path from "@std/path";
+import { denoPlugins } from "../src/plugin.ts";
 
 async function testEsbuild(options: {
   jsx?: BuildOptions["jsx"];
@@ -88,6 +95,19 @@ Deno.test({
 });
 
 Deno.test({
+  name: "resolves/loads - mapped entrypoint",
+  fn: async () => {
+    const res = await testEsbuild({
+      entryPoints: ["@fixtures/simple.ts"],
+    });
+
+    expect(res.outputFiles[0].text).toContain('console.log("hey")');
+  },
+  sanitizeResources: false,
+  sanitizeOps: false,
+});
+
+Deno.test({
   name: "resolves/loads - https:",
   fn: async () => {
     await testEsbuild({
@@ -156,32 +176,139 @@ Deno.test({
 });
 
 Deno.test({
-  name: "plugins can participate in resolution",
+  name: "plugins can participate in resolution and loading",
   fn: async () => {
-    const res = await testEsbuild({
-      entryPoints: [getFixture("mapped.ts")],
+    const [resolverPlugin, loaderPlugin] = denoPlugins();
+    const res = await build({
+      entryPoints: ["@fixtures/compiled"],
+      write: false,
+      format: "esm",
+      bundle: true,
       plugins: [
+        resolverPlugin,
         {
-          name: "test",
+          name: "multiply",
           setup(ctx) {
-            ctx.onResolve({ filter: /mapped$/ }, () => {
-              return {
-                path: getFixture("simple.ts"),
-                namespace: "test-internal",
-              };
-            });
+            ctx.onResolve(
+              { filter: /simple/ },
+              () => {
+                return {
+                  path: getFixture("simple.ts"),
+                  namespace: "file",
+                };
+              },
+            );
 
-            ctx.onLoad({ filter: /.*/, namespace: "test-internal" }, () => {
-              return {
-                contents: "hey",
-              };
-            });
+            ctx.onLoad(
+              { filter: /compiled.ts$/, namespace: "file" },
+              async (args: OnLoadArgs) => {
+                const url = path.toFileUrl(args.path);
+                const file = await Deno.readTextFile(url);
+                const contents = file.replaceAll(
+                  ": number =",
+                  ": number = 2 *",
+                );
+                return {
+                  contents,
+                  loader: "ts",
+                };
+              },
+            );
           },
         },
+        loaderPlugin,
       ],
     });
 
-    expect(res.outputFiles[0].text).toContain("hey");
+    expect(res.errors).toEqual([]);
+    expect(res.warnings).toEqual([]);
+    expect(res.outputFiles.length).toEqual(1);
+
+    const output = res.outputFiles[0].text;
+    expect(output).toContain('console.log("hey")');
+    const dataURL = `data:application/javascript;base64,${btoa(output)}`;
+    const { x, y } = await import(dataURL);
+    expect(x).toBe(4);
+    expect(y).toBe(6);
+  },
+  sanitizeResources: false,
+  sanitizeOps: false,
+});
+
+const cssPlugin: Plugin = {
+  name: "css",
+  setup(ctx) {
+    ctx.onLoad(
+      { filter: /.*\.css$/, namespace: "file" },
+      async (args: OnLoadArgs) => {
+        const url = path.toFileUrl(args.path);
+        const file = await Deno.readTextFile(url);
+        return {
+          contents: `export default ${JSON.stringify(file)}`,
+          loader: "js",
+        };
+      },
+    );
+  },
+};
+
+Deno.test({
+  name: "plugins can load entrypoints",
+  fn: async () => {
+    const [resolverPlugin, loaderPlugin] = denoPlugins();
+    const res = await build({
+      entryPoints: ["@fixtures/styles.css"],
+      write: false,
+      format: "esm",
+      bundle: true,
+      plugins: [
+        resolverPlugin,
+        cssPlugin,
+        loaderPlugin,
+      ],
+    });
+
+    expect(res.errors).toEqual([]);
+    expect(res.warnings).toEqual([]);
+    expect(res.outputFiles.length).toEqual(1);
+
+    const output = res.outputFiles[0].text;
+    expect(output).toContain("var styles_default = `.test {");
+    const dataURL = `data:application/javascript;base64,${btoa(output)}`;
+    const { default: styles } = await import(dataURL);
+    const fixturePath = getFixture("styles.css");
+    expect(styles).toBe(await Deno.readTextFile(fixturePath));
+  },
+  sanitizeResources: false,
+  sanitizeOps: false,
+});
+
+Deno.test({
+  name: "plugins can load non-entrypoints",
+  fn: async () => {
+    const [resolverPlugin, loaderPlugin] = denoPlugins();
+    const res = await build({
+      entryPoints: ["@fixtures/styles.ts"],
+      write: false,
+      format: "esm",
+      bundle: true,
+      plugins: [
+        resolverPlugin,
+        cssPlugin,
+        loaderPlugin,
+      ],
+    });
+
+    expect(res.errors).toEqual([]);
+    expect(res.warnings).toEqual([]);
+    expect(res.outputFiles.length).toEqual(1);
+
+    const output = res.outputFiles[0].text;
+    expect(output).toContain("var styles_default = `.test {");
+    const dataURL = `data:application/javascript;base64,${btoa(output)}`;
+    const { styles, name } = await import(dataURL);
+    expect(styles).toBe(await Deno.readTextFile(getFixture("styles.css")));
+    expect(name).toBe("main");
   },
   sanitizeResources: false,
   sanitizeOps: false,

--- a/tests/bundle.test.ts
+++ b/tests/bundle.test.ts
@@ -3,7 +3,6 @@ import {
   build,
   type BuildOptions,
   type OnLoadArgs,
-  OnResolveArgs,
   type Plugin,
 } from "esbuild";
 import { denoPlugin } from "@deno/esbuild-plugin";

--- a/tests/bundle.test.ts
+++ b/tests/bundle.test.ts
@@ -234,6 +234,56 @@ Deno.test({
   sanitizeOps: false,
 });
 
+Deno.test({
+  name:
+    "plugins can participate in resolution and loading after denoPlugin if using unique namespace",
+  fn: async () => {
+    const res = await testEsbuild({
+      entryPoints: ["@fixtures/mapped2"],
+      plugins: [
+        {
+          name: "multiply",
+          setup(ctx) {
+            ctx.onResolve(
+              { filter: /mapped2$/ },
+              () => {
+                return {
+                  path: getFixture("simple.ts"),
+                  namespace: "test-internal",
+                };
+              },
+            );
+
+            ctx.onLoad(
+              { filter: /.*/, namespace: "test-internal" },
+              async (args: OnLoadArgs) => {
+                const url = path.toFileUrl(args.path);
+                const file = await Deno.readTextFile(url);
+                return {
+                  contents: file + "\nexport const z: number = 3;\n",
+                  loader: "ts",
+                };
+              },
+            );
+          },
+        },
+      ],
+    });
+
+    expect(res.errors).toEqual([]);
+    expect(res.warnings).toEqual([]);
+    expect(res.outputFiles.length).toEqual(1);
+
+    const output = res.outputFiles[0].text;
+    expect(output).toContain('console.log("hey")');
+    const dataURL = `data:application/javascript;base64,${btoa(output)}`;
+    const { z } = await import(dataURL);
+    expect(z).toBe(3);
+  },
+  sanitizeResources: false,
+  sanitizeOps: false,
+});
+
 const cssPlugin: Plugin = {
   name: "css",
   setup(ctx) {

--- a/tests/fixtures/compiled.ts
+++ b/tests/fixtures/compiled.ts
@@ -1,0 +1,3 @@
+import "simple";
+export const x: number = 2;
+export const y: number = 3;

--- a/tests/fixtures/mapped2.ts
+++ b/tests/fixtures/mapped2.ts
@@ -1,0 +1,1 @@
+export { z } from "mapped2";

--- a/tests/fixtures/simple-import.ts
+++ b/tests/fixtures/simple-import.ts
@@ -1,0 +1,1 @@
+import "@fixtures/simple.ts";

--- a/tests/fixtures/styles.css
+++ b/tests/fixtures/styles.css
@@ -1,0 +1,7 @@
+.test {
+  color: red;
+}
+
+.test-svg {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ccircle%20r%3D'10'%20cx%3D'10'%20cy%3D'10'%20fill%3D'red'%20%2F%3E%3C%2Fsvg%3E");
+}

--- a/tests/fixtures/styles.ts
+++ b/tests/fixtures/styles.ts
@@ -1,0 +1,3 @@
+import styles from "@fixtures/styles.css";
+export { styles };
+export const name = "main";


### PR DESCRIPTION
Resolves https://github.com/denoland/deno-esbuild-plugin/issues/31

For this PR, I took the current denoPlugin setup functions body, and split it into 3 distinct functions. Then in the new denoPlugins function, I made it create separate resolver and loader plugins that share the same workspace.

The one existing test case related to plugins was broken, the one titled "plugins can participate in resolution". I re-wrote the test case to ensure both the onResolve and onLoad callbacks get called. The fake plugin being used before never had it's onResolve callback called because the mapped import was being caught and handled by the denoPlugin's onResolve since mapped exists in the import map. Then the onLoad callback wouldn't be called since the namespace would only get set if the fake plugins onResolve callback was called. Now I am having it import "simple" which is not in the import map. I have the onLoad callback transforming the code in a way that can easily be verified, it is multiplying the exported numbers by 2.